### PR TITLE
Close #10 Added warning that appears if insecureSkipTlsVerify is true

### DIFF
--- a/src/initializeContext.ts
+++ b/src/initializeContext.ts
@@ -7,9 +7,10 @@ export default async function initializeContext(
 ): Promise<OpenShiftExecutionContext> {
   const {
     instance: { config },
+    logger,
   } = context;
 
-  const openshift = new OpenShiftClient();
+  const openshift = new OpenShiftClient(logger);
   await openshift.authenticate(
     config.apiToken,
     config.cluster,

--- a/src/openshift/OpenShiftClient.test.ts
+++ b/src/openshift/OpenShiftClient.test.ts
@@ -21,7 +21,10 @@ describe("OpenShiftClient fetch ok data", () => {
   });
 
   async function getAuthenticatedClient() {
-    const openshift = new OpenShiftClient();
+    const logger = {
+      warn: jest.fn().mockImplementation(),
+    };
+    const openshift = new OpenShiftClient(logger as any);
     await openshift.authenticate(TOKEN, CLUSTER, true);
 
     return openshift;

--- a/src/openshift/OpenShiftClient.ts
+++ b/src/openshift/OpenShiftClient.ts
@@ -1,6 +1,7 @@
 // tslint:disable:no-var-requires
 const openshiftRestClient = require("openshift-rest-client").OpenshiftClient;
 
+import { IntegrationLogger } from "@jupiterone/jupiter-managed-integration-sdk";
 import {
   Deployment,
   Group,
@@ -14,6 +15,11 @@ import {
 
 export default class OpenShiftClient {
   private restClient: any;
+  private logger: IntegrationLogger;
+
+  constructor(logger: IntegrationLogger) {
+    this.logger = logger;
+  }
 
   public async authenticate(
     apiToken: string,
@@ -25,6 +31,12 @@ export default class OpenShiftClient {
       url: `https://${cluster}`,
       insecureSkipTlsVerify,
     };
+
+    if (config.insecureSkipTlsVerify) {
+      this.logger.warn(
+        "Attention! SSL/TLS certificate verification is disabled.",
+      );
+    }
 
     this.restClient = await openshiftRestClient({ config });
   }


### PR DESCRIPTION
There is a special flag in the config for Openshift Client - `insecureSkipTlsVerify`. A true value means that if the authenticity of the certificate is not established, then the execution will continue anyway (regardless of the type of certificate, self-signed or not). Also, it depends on `process.env.NODE_TLS_REJECT_UNAUTHORIZED`. So for enabling `insecureSkipTlsVerify` `process.env.NODE_TLS_REJECT_UNAUTHORIZED` must be `"0"`. Also, I've added `logger.warn` in the Client for `insecureSkipTlsVerify` true value. @aiwilliams, can you comment this? I think the problem is the wrong value of param. Will you have enough `logger.warn` call from our side for generating warn in UI? Or maybe we need to call another method?